### PR TITLE
Update FEniCS CI and tests

### DIFF
--- a/.github/workflows/ci-fenics.yml
+++ b/.github/workflows/ci-fenics.yml
@@ -18,9 +18,12 @@ jobs:
 
       - name: Setup Miniconda
         uses: conda-incubator/setup-miniconda@v2
-        with: 
+        with:
           auto-update-conda: true
           python-version: 3.8
+          mamba-version: "*"
+          channels: conda-forge,defaults
+          channel-priority: true
 
       - name: Conda info
         shell: bash -l {0}
@@ -28,12 +31,12 @@ jobs:
           conda info
           which python
 
-      - name: Conda install FEniCS
+      - name: Mamba install FEniCS
         shell: bash -l {0}
         run: |
           conda config --set always_yes yes
           conda config --add channels conda-forge
-          conda create -n fenicsproject -c conda-forge fenics
+          mamba create -n fenicsproject -c conda-forge fenics superlu_dist=6.2.0
           conda activate fenicsproject
           which python
           python -c "from dolfin import *"

--- a/jaxfenics_adjoint/core.py
+++ b/jaxfenics_adjoint/core.py
@@ -1,5 +1,6 @@
 import jax
 import jax.numpy as np
+from jax._src import ad_util
 
 from jax.core import Primitive
 from jax.custom_derivatives import custom_vjp
@@ -68,7 +69,7 @@ def get_pullback_function(
             fe_aux.tape,
         )
         return tuple(
-            vjp if vjp is not None else jax.ad_util.zeros_like_jaxval(args[i])
+            vjp if vjp is not None else ad_util.zeros_like_jaxval(args[i])
             for i, vjp in enumerate(
                 evaluate_pullback(fenics_output, fenics_inputs, tape, g)
             )

--- a/jaxfenics_adjoint/helpers.py
+++ b/jaxfenics_adjoint/helpers.py
@@ -1,4 +1,6 @@
 import jax
+from jax._src import ad_util
+from jax._src.abstract_arrays import ConcreteArray, ShapedArray
 import numpy as np
 
 import fecr
@@ -19,7 +21,7 @@ def jax_to_fenics_numpy(jax_array: JAXArray, fem_variable: BackendVariable) -> n
     fem_backend = fecr._backends.get_backend(fem_variable)
 
     # JAX tracer specific part. Here we return zero values if tracer is not ConcreteArray type.
-    if isinstance(jax_array, jax.ad_util.Zero):
+    if isinstance(jax_array, ad_util.Zero):
         if isinstance(fem_variable, fem_backend.lib.Constant):
             numpy_array = np.zeros_like(fem_variable.values())
             return numpy_array
@@ -31,15 +33,15 @@ def jax_to_fenics_numpy(jax_array: JAXArray, fem_variable: BackendVariable) -> n
         numpy_array = jax.core.get_aval(jax_array)
         return numpy_array
 
-    elif isinstance(jax_array, (jax.abstract_arrays.ShapedArray,)):
-        if not isinstance(jax_array, (jax.abstract_arrays.ConcreteArray,)):
+    elif isinstance(jax_array, (ShapedArray,)):
+        if not isinstance(jax_array, (ConcreteArray,)):
             warnings.warn(
                 "Got JAX tracer type to convert to FEniCS/Firedrake. Returning zero."
             )
             numpy_array = np.zeros(jax_array.shape)
             return numpy_array
 
-        elif isinstance(jax_array, (jax.abstract_arrays.ConcreteArray,)):
+        elif isinstance(jax_array, (ConcreteArray,)):
             numpy_array = jax_array.val
             return numpy_array
 

--- a/tests/fenics/test_assemble.py
+++ b/tests/fenics/test_assemble.py
@@ -44,9 +44,10 @@ def test_jacobian_and_vjp():
     jax_jac0 = jax.jacrev(hh0)(inputs[0])
     with check:
         assert np.allclose(fdm_jac0, jax_jac0)
-    v0 = np.asarray(onp.random.normal(size=(1,)))
-    fdm_vjp0 = v0 @ fdm_jac0
-    jax_vjp0 = jax.vjp(hh0, inputs[0])[1](v0)
+    v0 = np.asarray(onp.random.normal(size=()))
+    fdm_vjp0 = v0[None] @ fdm_jac0
+    # jax.vjp now returns a tuple
+    jax_vjp0 = jax.vjp(hh0, inputs[0])[1](v0)[0]
     with check:
         assert np.allclose(fdm_vjp0, jax_vjp0)
 
@@ -54,9 +55,10 @@ def test_jacobian_and_vjp():
     jax_jac1 = jax.jacrev(hh1)(inputs[1])
     with check:
         assert np.allclose(fdm_jac1, jax_jac1)
-    v1 = np.asarray(onp.random.normal(size=(1,)))
-    fdm_vjp1 = v1 @ fdm_jac1
-    jax_vjp1 = jax.vjp(hh1, inputs[1])[1](v1)
+    v1 = np.asarray(onp.random.normal(size=()))
+    fdm_vjp1 = v1[None] @ fdm_jac1
+    # jax.vjp now returns a tuple
+    jax_vjp1 = jax.vjp(hh1, inputs[1])[1](v1)[0]
     with check:
         assert np.allclose(fdm_vjp1, jax_vjp1)
 
@@ -64,9 +66,10 @@ def test_jacobian_and_vjp():
     jax_jac2 = jax.jacrev(hh2)(inputs[2])
     with check:
         assert np.allclose(fdm_jac2, jax_jac2)
-    v2 = np.asarray(onp.random.normal(size=(1,)))
-    fdm_vjp2 = v2 @ fdm_jac2
-    jax_vjp2 = jax.vjp(hh2, inputs[2])[1](v2)
+    v2 = np.asarray(onp.random.normal(size=()))
+    fdm_vjp2 = v2[None] @ fdm_jac2
+    # jax.vjp now returns a tuple
+    jax_vjp2 = jax.vjp(hh2, inputs[2])[1](v2)[0]
     with check:
         assert np.allclose(fdm_vjp2, jax_vjp2)
 

--- a/tests/fenics/test_helpers.py
+++ b/tests/fenics/test_helpers.py
@@ -7,13 +7,12 @@ from jaxfenics_adjoint import from_jax
 
 import jax
 from jax.config import config
+from jax.core import get_aval
+from jax._src import ad_util
+from jax._src.abstract_arrays import make_shaped_array
 import jax.numpy
 
 config.update("jax_enable_x64", True)
-
-# Test JAX specific conversions here
-make_shaped_array = jax.abstract_arrays.make_shaped_array
-get_aval = jax.core.get_aval
 
 
 @pytest.mark.parametrize(
@@ -22,8 +21,11 @@ get_aval = jax.core.get_aval
         (make_shaped_array(jax.numpy.ones(1)), fenics.Constant(0.0)),
         (make_shaped_array(jax.numpy.ones(2)), fenics.Constant([0.0, 0.0])),
         (get_aval(jax.numpy.asarray(0.66)), fenics.Constant(0.66)),
-        (get_aval(jax.numpy.asarray([0.5, 0.66])), fenics.Constant([0.5, 0.66]),),
-        (jax.ad_util.Zero(get_aval(jax.numpy.asarray(0.0))), fenics.Constant(0.0)),
+        (
+            get_aval(jax.numpy.asarray([0.5, 0.66])),
+            fenics.Constant([0.5, 0.66]),
+        ),
+        (ad_util.Zero(get_aval(jax.numpy.asarray(0.0))), fenics.Constant(0.0)),
     ],
 )
 def test_from_jax_constant(test_input, expected):
@@ -35,7 +37,7 @@ def test_from_jax_constant(test_input, expected):
     "test_input,expected_expr",
     [
         (make_shaped_array(jax.numpy.ones(10)), "0.0"),
-        (jax.ad_util.Zero(get_aval(jax.numpy.asarray(0.0))), "0.0"),
+        (ad_util.Zero(get_aval(jax.numpy.asarray(0.0))), "0.0"),
         (get_aval(jax.numpy.linspace(0.05, 0.95, num=10)), "x[0]"),
     ],
 )

--- a/tests/fenics/test_solve_rev.py
+++ b/tests/fenics/test_solve_rev.py
@@ -74,7 +74,8 @@ def test_jacobian_and_vjp():
             assert np.allclose(fdm_jac, jax_jac)
 
         fdm_vjp = v @ fdm_jac
-        jax_vjp = jax.vjp(func, inp)[1](v)
+        # jax.vjp now returns a tuple
+        jax_vjp = jax.vjp(func, inp)[1](v)[0]
 
         with check:
             assert np.allclose(fdm_vjp, jax_vjp)

--- a/tests/firedrake/test_assemble.py
+++ b/tests/firedrake/test_assemble.py
@@ -43,9 +43,10 @@ def test_jacobian_and_vjp():
     jax_jac0 = jax.jacrev(hh0)(inputs[0])
     with check:
         assert np.allclose(fdm_jac0, jax_jac0)
-    v0 = np.asarray(onp.random.normal(size=(1,)))
-    fdm_vjp0 = v0 @ fdm_jac0
-    jax_vjp0 = jax.vjp(hh0, inputs[0])[1](v0)
+    v0 = np.asarray(onp.random.normal(size=()))
+    fdm_vjp0 = v0[None] @ fdm_jac0
+    # jax.vjp now returns a tuple
+    jax_vjp0 = jax.vjp(hh0, inputs[0])[1](v0)[0]
     with check:
         assert np.allclose(fdm_vjp0, jax_vjp0)
 
@@ -53,9 +54,10 @@ def test_jacobian_and_vjp():
     jax_jac1 = jax.jacrev(hh1)(inputs[1])
     with check:
         assert np.allclose(fdm_jac1, jax_jac1)
-    v1 = np.asarray(onp.random.normal(size=(1,)))
-    fdm_vjp1 = v1 @ fdm_jac1
-    jax_vjp1 = jax.vjp(hh1, inputs[1])[1](v1)
+    v1 = np.asarray(onp.random.normal(size=()))
+    fdm_vjp1 = v1[None] @ fdm_jac1
+    # jax.vjp now returns a tuple
+    jax_vjp1 = jax.vjp(hh1, inputs[1])[1](v1)[0]
     with check:
         assert np.allclose(fdm_vjp1, jax_vjp1)
 
@@ -63,9 +65,10 @@ def test_jacobian_and_vjp():
     jax_jac2 = jax.jacrev(hh2)(inputs[2])
     with check:
         assert np.allclose(fdm_jac2, jax_jac2)
-    v2 = np.asarray(onp.random.normal(size=(1,)))
-    fdm_vjp2 = v2 @ fdm_jac2
-    jax_vjp2 = jax.vjp(hh2, inputs[2])[1](v2)
+    v2 = np.asarray(onp.random.normal(size=()))
+    fdm_vjp2 = v2[None] @ fdm_jac2
+    # jax.vjp now returns a tuple
+    jax_vjp2 = jax.vjp(hh2, inputs[2])[1](v2)[0]
     with check:
         assert np.allclose(fdm_vjp2, jax_vjp2)
 

--- a/tests/firedrake/test_helpers.py
+++ b/tests/firedrake/test_helpers.py
@@ -7,13 +7,12 @@ from jaxfenics_adjoint import from_jax
 
 import jax
 from jax.config import config
+from jax.core import get_aval
+from jax._src import ad_util
+from jax._src.abstract_arrays import make_shaped_array
 import jax.numpy
 
 config.update("jax_enable_x64", True)
-
-# Test JAX specific conversions here
-make_shaped_array = jax.abstract_arrays.make_shaped_array
-get_aval = jax.core.get_aval
 
 
 @pytest.mark.parametrize(
@@ -22,8 +21,11 @@ get_aval = jax.core.get_aval
         (make_shaped_array(jax.numpy.ones(1)), firedrake.Constant(0.0)),
         (make_shaped_array(jax.numpy.ones(2)), firedrake.Constant([0.0, 0.0])),
         (get_aval(jax.numpy.asarray(0.66)), firedrake.Constant(0.66)),
-        (get_aval(jax.numpy.asarray([0.5, 0.66])), firedrake.Constant([0.5, 0.66]),),
-        (jax.ad_util.Zero(get_aval(jax.numpy.asarray(0.0))), firedrake.Constant(0.0)),
+        (
+            get_aval(jax.numpy.asarray([0.5, 0.66])),
+            firedrake.Constant([0.5, 0.66]),
+        ),
+        (ad_util.Zero(get_aval(jax.numpy.asarray(0.0))), firedrake.Constant(0.0)),
     ],
 )
 def test_from_jax_constant(test_input, expected):
@@ -41,7 +43,7 @@ def _x0(mesh):
     [
         (make_shaped_array(jax.numpy.ones(10)), lambda mesh: firedrake.Constant(0.0)),
         (
-            jax.ad_util.Zero(get_aval(jax.numpy.asarray(0.0))),
+            ad_util.Zero(get_aval(jax.numpy.asarray(0.0))),
             lambda mesh: firedrake.Constant(0.0),
         ),
         (get_aval(jax.numpy.linspace(0.05, 0.95, num=10)), _x0),

--- a/tests/firedrake/test_solve_rev.py
+++ b/tests/firedrake/test_solve_rev.py
@@ -71,7 +71,8 @@ def test_jacobian_and_vjp():
             assert np.allclose(fdm_jac, jax_jac)
 
         fdm_vjp = v @ fdm_jac
-        jax_vjp = jax.vjp(func, inp)[1](v)
+        # jax.vjp now returns a tuple
+        jax_vjp = jax.vjp(func, inp)[1](v)[0]
 
         with check:
             assert np.allclose(fdm_vjp, jax_vjp)


### PR DESCRIPTION
A few changes to JAX made the package unusable with the current version (`0.2.24`). In addition, FEniCS CI was broken because the latest superlu_dist package is not working with the current FEniCS package.